### PR TITLE
ci: SHA-pin external actions and add dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,6 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 3
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,24 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "andysnowden"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 3
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: "10:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 3
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.6
+        uses: dependabot/fetch-metadata@4de7a6c08ce727a42e0adbbdc345f761a01240ce  # v1.3.6
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Test python
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
         with:
           python-version: '3.10'
       - name: Install requirements
@@ -22,6 +22,6 @@ jobs:
       - name: Run tests and collect coverage
         run: pytest --cov=converters --cov-report=xml
       - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v4.2.0
+        uses: codecov/codecov-action@7afa10ed9b269c561c2336fd862446844e0cbf71  # v4.2.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- SHA-pin all external GitHub Actions `uses:` references (except internal `PebblePost/pp-actions/*` refs, which remain on `@v1` per the documented consumption pattern in `pp-actions/README.md`). The original tag is preserved in a trailing comment so reviewers can see the source version at a glance.
- Add `cooldown` blocks to `npm` / `pip` / `gomod` dependabot ecosystems where missing, mirroring `platform-crm-adapter/.github/dependabot.yml`.
- Ensure the `github-actions` dependabot ecosystem exists, is on a `daily` schedule, and has a `cooldown` block.

No action versions were upgraded as part of this change — refs were resolved to the current SHA of the existing tag/branch.

## References

- [DEVOPS-4370](https://pebblepost.atlassian.net/browse/DEVOPS-4370)
- [DEVOPS-4259](https://pebblepost.atlassian.net/browse/DEVOPS-4259)

## Test plan

- [ ] CI runs green on this branch
- [ ] Copilot review addressed
- [ ] Verify no action versions were upgraded (compare `# <version>` trailing comments to current `uses:` SHAs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVOPS-4370]: https://pebblepost.atlassian.net/browse/DEVOPS-4370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEVOPS-4259]: https://pebblepost.atlassian.net/browse/DEVOPS-4259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ