### PR TITLE
fix(ci): pin codecov-action to fb8b3582 (v6.0.2) — DEVOPS-4415

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Run tests and collect coverage
         run: pytest --cov=converters --cov-report=xml
       - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@7afa10ed9b269c561c2336fd862446844e0cbf71  # v4.2.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Pins `codecov/codecov-action` to commit `fb8b3582c8e4def4969c97caa2f19720cb33a72f` (v6.0.2 / v7.0.0)
- Codecov migrated their GPG signing key on 2026-06-07 — all refs before v7.0.0/v6.0.2 fail to GPG-verify the downloaded CLI, breaking coverage uploads
- Part of a coordinated fix across all impacted PebblePost repos

## Test plan
- [ ] CI passes on this branch
- [ ] Coverage upload step succeeds in the workflow run

Tracks: DEVOPS-4415

🤖 Generated with [Claude Code](https://claude.ai/claude-code)